### PR TITLE
feat: 497 enable reading comma separated values from issuer property

### DIFF
--- a/src/main/java/ee/eesti/authentication/configuration/jwt/JwtUtils.java
+++ b/src/main/java/ee/eesti/authentication/configuration/jwt/JwtUtils.java
@@ -97,7 +97,7 @@ public class JwtUtils {
 
         JWTClaimsSet.Builder claimsSetBuilder = new JWTClaimsSet.Builder()
                 .jwtID(jwtTokenId.toString())
-                .issuer(jwtSignatureConfig.getIssuer())
+                .issuer(getFirstIssuer())
                 .issueTime(issueDate)
                 .expirationTime(expirationDate)
                 .subject(subject);
@@ -229,7 +229,7 @@ public class JwtUtils {
             if (signedJWT.getJWTClaimsSet().getJWTID() == null
                     || signedJWT.getJWTClaimsSet().getExpirationTime() == null
                     || signedJWT.getJWTClaimsSet().getIssueTime() == null
-                    || !jwtSignatureConfig.getIssuer().equals(signedJWT.getJWTClaimsSet().getIssuer())
+                    || !containsIssuer(signedJWT.getJWTClaimsSet().getIssuer())
                     ) {
                 log.warn("some attributes of the JWT token (id:{}) are invalid", signedJWT.getJWTClaimsSet().getJWTID());
                 valid = false;
@@ -270,6 +270,14 @@ public class JwtUtils {
 
     public static String removeNewlines(String in) {
         return in.replaceAll("[\n\r]+"," ");
+    }
+
+    public String getFirstIssuer() {
+        return jwtSignatureConfig.getIssuer().split(",")[0];
+    }
+
+    public boolean containsIssuer(String tokenIssuer) {
+        return Set.of(jwtSignatureConfig.getIssuer().split(",")).contains(tokenIssuer);
     }
 
 }

--- a/src/test/java/ee/eesti/authentication/configuration/jwt/JwtUtilsTest.java
+++ b/src/test/java/ee/eesti/authentication/configuration/jwt/JwtUtilsTest.java
@@ -63,7 +63,7 @@ class JwtUtilsTest extends AbstractSpringBasedTest {
         SignedJWT signedJWT = new SignedJWT(new JWSHeader(JWSAlgorithm.RS256),
                 new JWTClaimsSet.Builder()
                         .jwtID(UUID.randomUUID().toString())
-                        .issuer(jwtSignatureConfig.getIssuer())
+                        .issuer(jwtUtils.getFirstIssuer())
                         .issueTime(issueDate)
                         .expirationTime(expirationDate)
                         .subject(userInfo.getPersonalCode())

--- a/src/test/java/ee/eesti/authentication/controller/JwtControllerTest.java
+++ b/src/test/java/ee/eesti/authentication/controller/JwtControllerTest.java
@@ -128,7 +128,7 @@ class JwtControllerTest extends AbstractSpringBasedTest {
 
         mvc.perform(
                         get("/jwt/userinfo")
-                                .cookie(new Cookie(jwtSignatureConfig.getCookieName(), getJwtTokenString(issueTime, expirationDate, jwtSignatureConfig.getIssuer(), UUID.randomUUID().toString(), claimSetToAdd, personalCode))))
+                                .cookie(new Cookie(jwtSignatureConfig.getCookieName(), getJwtTokenString(issueTime, expirationDate, jwtUtils.getFirstIssuer(), UUID.randomUUID().toString(), claimSetToAdd, personalCode))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("personalCode", is(personalCode)))
                 .andExpect(jsonPath("firstName", is(firstName)))
@@ -161,7 +161,7 @@ class JwtControllerTest extends AbstractSpringBasedTest {
         //Valid Token
         mvc.perform(
                         post("/jwt/verify")
-                                .content(getJwtTokenString(new Date(), DateUtils.addMinutes(new Date(), 30), jwtSignatureConfig.getIssuer(), UUID.randomUUID().toString(), null, personalCode)))
+                                .content(getJwtTokenString(new Date(), DateUtils.addMinutes(new Date(), 30), jwtUtils.getFirstIssuer(), UUID.randomUUID().toString(), null, personalCode)))
                 .andExpect(status().isOk());
 
         //invalid token
@@ -173,7 +173,7 @@ class JwtControllerTest extends AbstractSpringBasedTest {
         //Expired token
         mvc.perform(
                         post("/jwt/verify")
-                                .content(getJwtTokenString(new Date(), new Date(), jwtSignatureConfig.getIssuer(), UUID.randomUUID().toString(), null, personalCode)))
+                                .content(getJwtTokenString(new Date(), new Date(), jwtUtils.getFirstIssuer(), UUID.randomUUID().toString(), null, personalCode)))
                 .andExpect(status().isBadRequest());
 
         //Invalid issuer


### PR DESCRIPTION
Added and starting using two utility functions in JwtUtils, to support comma separated values from jwt-integration.signature.issuer property